### PR TITLE
Testing workflow again

### DIFF
--- a/.github/workflows/deploy-hardhat.yml
+++ b/.github/workflows/deploy-hardhat.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Copy over hardhat files to running container
       run: |
+        docker exec devnet mkdir -p /workspace/hardhat
         docker cp ${{ github.workspace }}/hardhat devnet:/workspace/hardhat
         docker exec devnet ls /workspace/hardhat
         docker exec devnet ls -l /workspace/hardhat


### PR DESCRIPTION
In the previous version of the workflow, it only mounted the files needed for hardhat so later when I built the new image they were not present.